### PR TITLE
Update io_import_georaster.py

### DIFF
--- a/io_import_georaster.py
+++ b/io_import_georaster.py
@@ -827,7 +827,7 @@ from bpy.types import Operator
 
 class IMPORT_GEORAST(Operator, ImportHelper):
 	"""Import georeferenced raster (need world file)"""
-	bl_idname = "import.georaster"  # important since its how bpy.ops.import.georaster is constructed
+	bl_idname = "import_gis.rast"  # important since its how bpy.ops.import.georaster is constructed
 	bl_description = 'Import raster georeferenced with world file'
 	bl_label = "Import georaster"
 	bl_options = {"UNDO"}


### PR DESCRIPTION
Using Blender 2.72 on a Linux computer I couldn't call your addon from the python console with its original bl_idname (import.georaster), I changed it for import_gis.rast and now it works. 
Thanks a lot for your addon, it's great.