### PR TITLE
Objects names not always imported

### DIFF
--- a/io_shapefile/op_import_shp.py
+++ b/io_shapefile/op_import_shp.py
@@ -291,7 +291,7 @@ class IMPORT_SHP(Operator):
 		fieldsNames = [field[0] for field in fields]
 		#print("DBF fields : "+str(fieldsNames))
 
-		if self.fieldElevName or self.fieldElevName or self.fieldExtrudeName:
+		if self.fieldElevName or (self.fieldObjName and self.separateObjects) or self.fieldExtrudeName:
 			self.useDbf = True
 		else:
 			self.useDbf = False


### PR DESCRIPTION
Hi,
An error in useDbf condition prevent names from being imported when fieldElevName and fieldExtrudeName are not set.
Checking for (self.fieldObjName and self.separateObjects) fix this issue