### PR TITLE
Fix "stat: path too long for Windows" error

### DIFF
--- a/osm/overpy/__init__.py
+++ b/osm/overpy/__init__.py
@@ -146,7 +146,11 @@ class Overpass(object):
         :rtype: overpy.Result
         """
 
-        if not os.path.exists(data):
+        try:
+            isFile = os.path.exists(data)
+        except:
+            isFile = False
+        if not isFile:
 
             if isinstance(data, bytes):
                 data = data.decode(encoding)
@@ -282,7 +286,11 @@ class Result(object):
         """
         result = cls(api=api)
 
-        if not os.path.exists(data):
+        try:
+            isFile = os.path.exists(data)
+        except:
+            isFile = False
+        if not isFile:
             data = StringIO(data)
         root = ET.iterparse(data, events=("start", "end"))
         elem_clss = {'node':Node, 'way':Way, 'relation':Relation}


### PR DESCRIPTION
Python dosen't support long filenames on Windows platform and os.path.exists() call with long strings throw an error.
Use try and except to fix this issue.