### PR TITLE
Remove PIL Image Class override

### DIFF
--- a/lib/Tyf/__init__.py
+++ b/lib/Tyf/__init__.py
@@ -497,32 +497,6 @@ else:
 		fileobj.close()
 		return exif
 
-	class Image(_Image.Image):
-
-		_image_ = _Image.Image
-
-		@staticmethod
-		def open(*args, **kwargs):
-			return _Image.open(*args, **kwargs)
-
-		def save(self, fp, format="JPEG", **params):
-
-			ifd = params.pop("ifd", False)
-			if ifd != False:
-				fileobj = StringIO()
-				if isinstance(ifd, TiffFile):
-					ifd.load_raster()
-					ifd.save(fileobj)
-				elif isinstance(ifd, JpegFile):
-					ifd[0xffe1].save(fileobj)
-				data = fileobj.getvalue()
-				fileobj.close()
-				if len(data) > 0:
-					params["exif"] = b"Exif\x00\x00" + (data.encode() if isinstance(data, str) else data)
-
-			Image._image_.save(self, fp, format="JPEG", **params)
-	_Image.Image = Image
-
 	from PIL import JpegImagePlugin
 	JpegImagePlugin._getexif = _getexif
 	del _getexif


### PR DESCRIPTION
PIL Image class override crash mapviewer under windows 10.
As this module dosen't use Image, there is no reason to keep this override.