### PR TITLE
[bugfix] adjust3dview dosen't like INF

### DIFF
--- a/utils/bpu.py
+++ b/utils/bpu.py
@@ -7,7 +7,10 @@ import bpy
 def adjust3Dview(context, bbox, zoomToSelect=True):
 
 	# grid size and clip distance
-	dstMax = round(max(abs(bbox.xmax), abs(bbox.xmin), abs(bbox.ymax), abs(bbox.ymin)))*2
+	try:
+		dstMax = round(max(abs(bbox.xmax), abs(bbox.xmin), abs(bbox.ymax), abs(bbox.ymin)))*2
+	except:
+		return
 	nbDigit = len(str(dstMax))
 	scale = 10**(nbDigit-2)#1 digits --> 0.1m, 2 --> 1m, 3 --> 10m, 4 --> 100m, , 5 --> 1000m
 	nbLines = round(dstMax/scale)


### PR DESCRIPTION
Use try for adjust3dview while some files import may result in dx or dy being INF and result in cannot convert float infinity to integer exception.

When reported by shp importer, such error means CSR used to import the file is probably wrong. eg:wgs84 while the file is in national coords. 

Should report the error to user, based on bbox containing +- INF values.

Ultimately for shp with .prj we also may provide auto-detection using on-line service such as 
http://prj2epsg.org/search
http://prj2epsg.org/apidocs.html
