### PR TITLE
Added replacement for time.clock() (removed after py v3.8)

### DIFF
--- a/core/maths/kmeans1D.py
+++ b/core/maths/kmeans1D.py
@@ -28,6 +28,7 @@ In contrast, this script works in a reasonable time, but keep in mind it's not J
 reference to distribute the values while Jenks try to minimize within-class variance, and maximizes between group variance.
 """
 
+from ..utils.timing import perf_clock
 
 
 def kmeans1d(data, k, cutoff=False, maxIter=False):
@@ -174,9 +175,9 @@ if __name__ == '__main__':
 
 	print('---------------')
 	print('%i values, %i classes' %(len(data),k))
-	t1 = time.clock()
+	t1 = perf_clock()
 	clusters = kmeans1d(data, k)
-	t2 = time.clock()
+	t2 = perf_clock()
 	print('Completed in %f seconds' %(t2-t1))
 
 	print('Breaks :')

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,3 +1,4 @@
 from .xy import XY
 from .bbox import BBOX
 from .gradient import Color, Stop, Gradient
+from .timing import perf_clock

--- a/core/utils/timing.py
+++ b/core/utils/timing.py
@@ -1,0 +1,9 @@
+import time
+
+def perf_clock():
+    if hasattr(time, 'clock'):
+        return time.clock()
+    elif hasattr(time, 'perf_counter'):
+        return time.perf_counter()
+    else:
+        raise Exception("Python time lib doesn't contain a suitable clock function")

--- a/operators/io_import_osm.py
+++ b/operators/io_import_osm.py
@@ -18,6 +18,7 @@ from .utils import adjust3Dview, getBBOX, DropToGround, isTopView
 
 from ..core.proj import Reproj, reprojBbox, reprojPt, utm
 from ..core.settings import getSetting
+from ..core.utils import perf_clock
 
 USER_AGENT = getSetting('user_agent')
 
@@ -558,12 +559,12 @@ class IMPORTGIS_OT_osm_file(Operator, OSM_IMPORT):
 			return {'CANCELLED'}
 
 		#Parse file
-		t0 = time.clock()
+		t0 = perf_clock()
 		api = overpy.Overpass()
 		#with open(self.filepath, "r", encoding"utf-8") as f:
 		#	result = api.parse_xml(f.read()) #WARNING read() load all the file into memory
 		result = api.parse_xml(self.filepath)
-		t = time.clock() - t0
+		t = perf_clock() - t0
 		log.info('File parsed in {} seconds'.format(round(t, 2)))
 
 		#Get bbox
@@ -584,9 +585,9 @@ class IMPORTGIS_OT_osm_file(Operator, OSM_IMPORT):
 			geoscn.setOriginPrj(x, y)
 
 		#Build meshes
-		t0 = time.clock()
+		t0 = perf_clock()
 		self.build(context, result, geoscn.crs)
-		t = time.clock() - t0
+		t = perf_clock() - t0
 		log.info('Mesh build in {} seconds'.format(round(t, 2)))
 
 		bbox = getBBOX.fromScn(scn)

--- a/operators/io_import_shp.py
+++ b/operators/io_import_shp.py
@@ -16,6 +16,7 @@ from ..geoscene import GeoScene, georefManagerLayout
 from ..prefs import PredefCRS
 from ..core import BBOX
 from ..core.proj import Reproj
+from ..core.utils import perf_clock
 
 from .utils import adjust3Dview, getBBOX, DropToGround
 
@@ -340,7 +341,7 @@ class IMPORTGIS_OT_shapefile(Operator):
 		#Set cursor representation to 'loading' icon
 		w = context.window
 		w.cursor_set('WAIT')
-		t0 = time.clock()
+		t0 = perf_clock()
 
 		bpy.ops.object.select_all(action='DESELECT')
 
@@ -727,7 +728,7 @@ class IMPORTGIS_OT_shapefile(Operator):
 		#free the bmesh
 		bm.free()
 
-		t = time.clock() - t0
+		t = perf_clock() - t0
 		log.info('Build in %f seconds' % t)
 
 		#Adjust grid size

--- a/operators/mesh_delaunay_voronoi.py
+++ b/operators/mesh_delaunay_voronoi.py
@@ -212,7 +212,7 @@ class OBJECT_OT_tesselation_voronoi(bpy.types.Operator):
 		voronoiObj.select_set(True)
 		obj.select_set(False)
 		#Report
-		t = round(timing.perf_clock() - t0, 2)
+		t = round(perf_clock() - t0, 2)
 		if self.meshType == "Edges":
 			self.report({'INFO'}, "{} edges created in {} seconds".format(len(edgesIdx), t))
 		else:

--- a/operators/mesh_delaunay_voronoi.py
+++ b/operators/mesh_delaunay_voronoi.py
@@ -3,6 +3,7 @@
 import bpy
 import time
 from .utils import computeVoronoiDiagram, computeDelaunayTriangulation
+from ..core.utils import perf_clock
 
 try:
 	from mathutils.geometry import delaunay_2d_cdt
@@ -50,7 +51,7 @@ class OBJECT_OT_tesselation_delaunay(bpy.types.Operator):
 	def execute(self, context):
 		w = context.window
 		w.cursor_set('WAIT')
-		t0 = time.clock()
+		t0 = perf_clock()
 		#Get selected obj
 		objs = context.selected_objects
 		if len(objs) == 0 or len(objs) > 1:
@@ -125,7 +126,7 @@ class OBJECT_OT_tesselation_delaunay(bpy.types.Operator):
 		tinObj.select_set(True)
 		obj.select_set(False)
 		#Report
-		t = round(time.clock() - t0, 2)
+		t = round(perf_clock() - t0, 2)
 		msg = "{} triangles created in {} seconds".format(len(faces), t)
 		self.report({'INFO'}, msg)
 		#log.info(msg) #duplicate log
@@ -150,7 +151,7 @@ class OBJECT_OT_tesselation_voronoi(bpy.types.Operator):
 	def execute(self, context):
 		w = context.window
 		w.cursor_set('WAIT')
-		t0 = time.clock()
+		t0 = perf_clock()
 		#Get selected obj
 		objs = context.selected_objects
 		if len(objs) == 0 or len(objs) > 1:
@@ -211,7 +212,7 @@ class OBJECT_OT_tesselation_voronoi(bpy.types.Operator):
 		voronoiObj.select_set(True)
 		obj.select_set(False)
 		#Report
-		t = round(time.clock() - t0, 2)
+		t = round(timing.perf_clock() - t0, 2)
 		if self.meshType == "Edges":
 			self.report({'INFO'}, "{} edges created in {} seconds".format(len(edgesIdx), t))
 		else:


### PR DESCRIPTION
time.clock() was deprecated in v3.3 and removed in 3.8
[https://docs.python.org/3/whatsnew/3.8.html](https://docs.python.org/3/whatsnew/3.8.html)

I added a little compatibility check so timing functions work both with python < 3.8 and >= 3.8.

I used time.perf_counter() instead of time.process_time(). The former includes other process' cpu time (real elapsed time).