### PR TITLE
Save srtm with a filename based on the object name

### DIFF
--- a/operators/io_get_dem.py
+++ b/operators/io_get_dem.py
@@ -105,9 +105,9 @@ class IMPORTGIS_OT_dem_query(Operator):
 		# Download the file from url and save it locally
 		# opentopo return a geotiff object in wgs84
 		if bpy.data.is_saved:
-			filePath = os.path.join(os.path.dirname(bpy.data.filepath), 'srtm.tif')
+			filePath = os.path.join(os.path.dirname(bpy.data.filepath), aObj.name + 'srtm.tif')
 		else:
-			filePath = os.path.join(bpy.app.tempdir, 'srtm.tif')
+			filePath = os.path.join(bpy.app.tempdir, aObj.name + 'srtm.tif')
 
 		#we can directly init NpImg from blob but if gdal is not used as image engine then georef will not be extracted
 		#Alternatively, we can save on disk, open with GeoRaster class (will use tyf if gdal not available)


### PR DESCRIPTION
Pulling srtm elevation data on multiple objects results in the srtm.tif heightmap file being overwritten. This patch adds a prefix to the filename based on the Blender object name, to avoid this overwrite.