### PR TITLE
Improve query performance. Re: Issue #470

### DIFF
--- a/core/basemaps/gpkg.py
+++ b/core/basemaps/gpkg.py
@@ -257,13 +257,23 @@ class GeoPackage():
 
 		db = sqlite3.connect(self.dbPath, detect_types=sqlite3.PARSE_DECLTYPES)
 
-		tiles = ['_'.join(map(str, tile)) for tile in tiles]
+		# split out the axises
+		x, y, z = zip(*tiles)
 
 		query = "SELECT tile_column, tile_row, zoom_level FROM gpkg_tiles " \
-				"WHERE julianday() - julianday(last_modified) < " + str(self.MAX_DAYS) + " " \
-				"AND tile_column || '_' || tile_row || '_' || zoom_level IN ('" + "','".join(tiles) + "')"
+				"WHERE julianday() - julianday(last_modified) < ?" \
+				"AND zoom_level BETWEEN ? AND ? AND tile_column BETWEEN ? AND ? AND tile_row BETWEEN ? AND ?"
 
-		result = db.execute(query).fetchall()
+		result = db.execute(
+			query,
+			(
+				GeoPackage.MAX_DAYS,
+				min(z), max(z),
+				min(x), max(x),
+				min(y), max(y)
+			)
+		).fetchall()
+
 		db.close()
 
 		return set(result)
@@ -279,13 +289,22 @@ class GeoPackage():
 
 		db = sqlite3.connect(self.dbPath, detect_types=sqlite3.PARSE_DECLTYPES)
 
-		tiles = ['_'.join(map(str, tile)) for tile in tiles]
+		# split out the axises
+		x, y, z = zip(*tiles)
 
 		query = "SELECT tile_column, tile_row, zoom_level, tile_data FROM gpkg_tiles " \
-				"WHERE julianday() - julianday(last_modified) < " + str(self.MAX_DAYS) + " " \
-				"AND tile_column || '_' || tile_row || '_' || zoom_level IN ('" + "','".join(tiles) + "')"
+				"WHERE julianday() - julianday(last_modified) < ?" \
+				"AND zoom_level BETWEEN ? AND ? AND tile_column BETWEEN ? AND ? AND tile_row BETWEEN ? AND ?"
 
-		result = db.execute(query).fetchall()
+		result = db.execute(
+			query,
+			(
+				GeoPackage.MAX_DAYS,
+				min(z), max(z),
+				min(x), max(x),
+				min(y), max(y)
+			)
+		).fetchall()
 
 		db.close()
 


### PR DESCRIPTION
Background for the issue this PR solves can be found in Issue #470.

It's a lot faster now.  I can provide more detailed benchmarks and explanations if you really want.

The only "drawback" this code makes is that it assumes that the resulting set of tiles form a rectangle.  It does this to avoid having to search a list of tile cords which is expensive for larger sets of tiles by.  Looking at other parts of the code it would appear that the general assumption that the results will be rectangular so I felt safe doing it this way.

In any case I've been seeing ~5000% speedup in query times.  I can post benchmarks if you really want them but `getTiles` ran in  0.1198s for 5700 tiles when pulling from my NVME drive and `listExistingTiles` ran in 2.1687s checking 356506 tiles (given that it was a partial set I would expect slightly higher times on a full set).