### PR TITLE
Add ability to animate shapefiles

### DIFF
--- a/operators/io_import_shp.py
+++ b/operators/io_import_shp.py
@@ -194,7 +194,7 @@ class IMPORTGIS_OT_shapefile_props_dialog(Operator):
 			default=False )
 
 	#Animate across shapefiles
-	animate = BoolProperty(
+	animate: BoolProperty(
 			name="Animate",
 			description="Animate across other shapefiles in the same folder",
 			default=False )

--- a/operators/io_import_shp.py
+++ b/operators/io_import_shp.py
@@ -314,7 +314,7 @@ class IMPORTGIS_OT_shapefile_props_dialog(Operator):
 					obj["area"] = area
 					log.info("{} has {} vertices and an area of {}".format(obj.name, vertex_count, area))
 					triangulate = obj.modifiers.new("TRIANGULATE", "TRIANGULATE")
-					bpy.ops.object.modifier_apply(apply_as='DATA', modifier="TRIANGULATE")
+					bpy.ops.object.modifier_apply(modifier="TRIANGULATE")
 
 					# Subsurf to smooth edges
 					n_cuts_required = int(round(math.log(500.0 / vertex_count, 2)))
@@ -322,7 +322,7 @@ class IMPORTGIS_OT_shapefile_props_dialog(Operator):
 						print(n_cuts_required)
 						subsurf = obj.modifiers.new("SUBSURF", "SUBSURF")
 						subsurf.levels = n_cuts_required
-						bpy.ops.object.modifier_apply(apply_as='DATA', modifier="SUBSURF")
+						bpy.ops.object.modifier_apply(modifier="SUBSURF")
 					objects.append(obj)
 					log.info("After triangulation / subsurf {} has {} vertices".format(obj.name, len(obj.data.vertices)))
 
@@ -345,7 +345,7 @@ class IMPORTGIS_OT_shapefile_props_dialog(Operator):
 					shrinkwrap = duplicated_base.modifiers.new("SHRINKWRAP", "SHRINKWRAP")
 					shrinkwrap.target = obj
 					#shrinkwrap.wrap_method = "NEAREST_VERTEX"
-					bpy.ops.object.modifier_apply(apply_as='DATA', modifier="SHRINKWRAP")
+					bpy.ops.object.modifier_apply(modifier="SHRINKWRAP")
 					# Copy vertex data from shrinkwrapped duplicate as a shape key
 					base_obj.shape_key_add(name=str(obj["frame"]))
 					for j, vertex in enumerate(duplicated_base.data.vertices):


### PR DESCRIPTION
This PR adds two ways of animating shapefiles using shape keys and keyframes.

## Option 1:

This feature would be useful for animating the differences between shapefiles, representing some change over time of polygon areas. The example I used to develop this represents the simulated flow of lava over time.

Usage:
Pass a folder of shapefiles, and animate between them. Each shapefile is expected to contain a different polygon, with each file representing some timestep. If the filename contains a number, that number is used as the frame number for that shapefile.
Here's the dataset I used to test when developing:
[Scenario F Birkenhead Northern Flow.zip](https://github.com/domlysz/BlenderGIS/files/6797839/Scenario.F.Birkenhead.Northern.Flow.zip)
The strategy to combine the shapefiles used is iterative shrinkwrapping using the shrinkwrap modifier (https://docs.blender.org/manual/en/latest/modeling/modifiers/deform/shrinkwrap.html.). This strategy works best if the shapes are growing or shrinking in some way.

Result:
https://www.youtube.com/watch?v=iQjB-P_-8zo&ab_channel=CenterforeResearch

## Option 2:

This feature would be useful for showing change in elevation over time. For example, erosion / deposition.

Usage:
Pass a shapefile that contains multiple elevation fields. Choose a sample field representing elevation (for example, Epoch1). Shape keys are generated for each field following the pattern (Epoch2, Epoch3, etc), and keyframes are generated animating between them. The numeric part of the field name is used as the frame number. Here's the shapefile I used when developing this:
[river.zip](https://github.com/domlysz/BlenderGIS/files/6797852/river.zip)
