### PR TITLE
Extend "apply curvature" to planetary bodies

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -234,8 +234,8 @@ class VIEW3D_MT_menu_gis_mesh(bpy.types.Menu):
 			self.layout.operator("tesselation.voronoi", icon_value=icons_dict["voronoi"].icon_id, text='Voronoi')
 		if EARTH_SPHERE:
 			self.layout.operator("earth.sphere", icon="WORLD", text='lonlat to sphere')
-			#self.layout.operator("earth.curvature", icon="SPHERECURVE", text='Earth curvature correction')
-			self.layout.operator("earth.curvature", icon_value=icons_dict["curve"].icon_id, text='Earth curvature correction')
+			#self.layout.operator("surface.curvature", icon="SPHERECURVE", text='Earth curvature correction')
+			self.layout.operator("surface.curvature", icon_value=icons_dict["curve"].icon_id, text='Surface curvature correction')
 
 class VIEW3D_MT_menu_gis_object(bpy.types.Menu):
 	bl_label = "Object"

--- a/operators/mesh_earth_sphere.py
+++ b/operators/mesh_earth_sphere.py
@@ -55,18 +55,20 @@ class OBJECT_OT_earth_sphere(Operator):
 
 		return {'FINISHED'}
 
-EARTH_RADIUS = 6378137 #meters
-def getZDelta(d):
+#EARTH_RADIUS = 6378137 #meters
+def getZDelta(d, radius=6378137):
 	'''delta value for adjusting z across earth curvature
 	http://webhelp.infovista.com/Planet/62/Subsystems/Raster/Content/help/analysis/viewshedanalysis.html'''
-	return sqrt(EARTH_RADIUS**2 + d**2) - EARTH_RADIUS
+	return sqrt(radius**2 + d**2) - radius
 
 
-class OBJECT_OT_earth_curvature(Operator):
-	bl_idname = "earth.curvature"
-	bl_label = "Earth curvature correction"
+class OBJECT_OT_surface_curvature(Operator):
+	bl_idname = "surface.curvature"
+	bl_label = "Surface curvature correction"
 	bl_description = "Apply earth curvature correction for viewsheed analysis"
 	bl_options = {"REGISTER", "UNDO"}
+
+	radius: IntProperty(name = "Radius", default=6378137, description="Sphere radius", min=1)
 
 	def execute(self, context):
 		scn = bpy.context.scene
@@ -85,14 +87,14 @@ class OBJECT_OT_earth_curvature(Operator):
 
 		for vertex in mesh.vertices:
 			d = (viewpt.xy - vertex.co.xy).length
-			vertex.co.z = vertex.co.z - getZDelta(d)
+			vertex.co.z = vertex.co.z - getZDelta(d, self.radius)
 
 		return {'FINISHED'}
 
 
 classes = [
 	OBJECT_OT_earth_sphere,
-	OBJECT_OT_earth_curvature
+	OBJECT_OT_surface_curvature
 ]
 
 def register():


### PR DESCRIPTION
As I'm working with planetary DEMs, I need to use a radius different from Earth's for the `earth_curvature` function/operator. I could easily change the value of EARTH_RADIUS for my specific use, but it could be nice to leave the user choose the radius (as for the `lonlat to sphere` function). I sketched a solution in this PR.

However, it's still not optimal: the function is applied once with the default radius value, then changing the radius causes a second correction (on top of the first one). Any suggestion how to avoid this?

Also before my mod, nothing prevents from applying this correction over and over: as this is untracked and w/o warning, it can lead to unexpected results and it's dangerous in my opinion.

Thanks for the super useful add-on, by the way!