### PR TITLE
Find world file for .jpeg extension

### DIFF
--- a/core/georaster/georaster.py
+++ b/core/georaster/georaster.py
@@ -111,6 +111,7 @@ class GeoRaster():
 		extTest.append(extTest[0]+'x')# tfwx
 		extTest.append(ext+'w')# tifw
 		extTest.append('wld')#*.wld
+		extTest.append('gw')# jgw for jpeg file extensions
 		extTest.extend( [ext.upper() for ext in extTest] )
 		for wfExt in extTest:
 			pathTest = self.path[0:len(self.path)-3] + wfExt


### PR DESCRIPTION
Thanks for the amazing add-on! I'm new to this please ignore if I'm way off base here.

Adds the ability to load .jpegs with .jgw world files.
fixes: https://github.com/domlysz/BlenderGIS/issues/568

Because the splitting of extensions is based on the last three characters in the path ([-3:]) the extension in foo.jpeg ends up being "peg" and the path ends up being "foo.j" so for the test I am appending "gw" to "foo.j to get "foo.jgw".

I am new to coding and this seems like it works and is in line with the other extension tests. However it doesn't seem very robust. I wonder if using os.path.splitext() and a list of world file extensions to check would be simpler.

I can imagine a scenario where you have both a jpeg and a png in the same folder with the same name and it would pick up the wrong world file. In which case it should be: if this file extension then look for these world file extensions.

Tiff files with .tiff extensions with world files don't and no internal georeferencing might have the same probelm.