### PR TITLE
add additional basemap types to Google Basemaps

### DIFF
--- a/core/basemaps/servicesDefs.py
+++ b/core/basemaps/servicesDefs.py
@@ -147,7 +147,9 @@ SOURCES = {
 		"quadTree": False,
 		"layers" : {
 			"SAT" : {"urlKey" : 's', "name" : 'Satellite', "description" : '', "format" : 'jpeg', "zmin" : 0, "zmax" : 22},
-			"MAP" : {"urlKey" : 'm', "name" : 'Map', "description" : '', "format" : 'png', "zmin" : 0, "zmax" : 22}
+			"MAP" : {"urlKey" : 'm', "name" : 'Map', "description" : '', "format" : 'png', "zmin" : 0, "zmax" : 22},
+			"HYB" : {"urlKey" : 'y', "name" : 'Hybrid', "description" : '', "format" : 'jpeg', "zmin" : 0, "zmax" : 22},
+			"TER" : {"urlKey" : 'p', "name" : 'Terrain', "description" : '', "format" : 'jpeg', "zmin" : 0, "zmax" : 22},
 		},
 		"urlTemplate": "http://mt0.google.com/vt/lyrs={LAY}&x={X}&y={Y}&z={Z}",
 		"referer": "https://www.google.com/maps"


### PR DESCRIPTION
added two additional types of basemaps that can be rendered from Google: Hybrid (Satellite + Map) and Terrain.

there are some other more niche map types [documented here](https://stackoverflow.com/a/33023651) - but these probably aren't useful for basemaps. a particularly interesting one, however is the "Terrain Only" option which seems to provide a relief map of the terrain that might work in normal maps, but I haven't tried this out. I've left it out of this PR.

tested in Blender 3.1.2.