### PR TITLE
Add support for locating arm64 freeimage dylib

### DIFF
--- a/core/lib/imageio/core/util.py
+++ b/core/lib/imageio/core/util.py
@@ -14,6 +14,7 @@ import sys
 import time
 import struct
 from warnings import warn
+import platform
 
 import numpy as np
 
@@ -516,7 +517,7 @@ def get_platform():
     
     Get a string that specifies the platform more specific than
     sys.platform does. The result can be: linux32, linux64, win32,
-    win64, osx32, osx64. Other platforms may be added in the future.
+    win64, osx32, osx64, osx-arm64. Other platforms may be added in the future.
     """
     # Get platform
     if sys.platform.startswith('linux'):
@@ -524,11 +525,19 @@ def get_platform():
     elif sys.platform.startswith('win'):
         plat = 'win%i'
     elif sys.platform.startswith('darwin'):
-        plat = 'osx%i'
+        if platform.machine() == 'arm64':
+            plat = 'osx-arm64'
+        else:
+            plat = 'osx%i'
     else:  # pragma: no cover
         return None
     
-    return plat % (struct.calcsize('P') * 8)  # 32 or 64 bits
+    # Only perform string formatting when plat contains '%i'
+    if '%i' in plat:
+        return plat % (struct.calcsize('P') * 8)  # 32 or 64 bits
+    else:
+        return plat
+
 
 
 def has_module(module_name):

--- a/core/lib/imageio/plugins/_freeimage.py
+++ b/core/lib/imageio/plugins/_freeimage.py
@@ -31,6 +31,7 @@ TEST_NUMPY_NO_STRIDES = False  # To test pypy fallback
 FNAME_PER_PLATFORM = {
     'osx32': 'libfreeimage-3.16.0-osx10.6.dylib',  # universal library
     'osx64': 'libfreeimage-3.16.0-osx10.6.dylib',
+    'osx-arm64': 'libfreeimage.3.18.0.dylib',
     'win32': 'FreeImage-3.15.4-win32.dll',
     'win64': 'FreeImage-3.15.1-win64.dll',
     'linux32': 'libfreeimage-3.16.0-linux32.so',


### PR DESCRIPTION
Partially addresses issue  #851. I am not sure where to find a good source for directly downloading an arm64 compatible version of freeimage to guide users to in the FAQ. I used homebrew to get libfreeimage.3.18.0.dylib, but I am not sure how to best download the dylib directly. Homebrew Source: https://sourceforge.net/projects/freeimage/