### PR TITLE
replacement of imghdr

### DIFF
--- a/core/basemaps/mapservice.py
+++ b/core/basemaps/mapservice.py
@@ -26,7 +26,6 @@ import threading
 import queue
 import time
 import urllib.request
-import imghdr
 import sys, time, os
 
 #core imports
@@ -37,6 +36,8 @@ from ..utils import BBOX
 from ..proj.reproj import reprojPt, reprojBbox, reprojImg
 from ..proj.ellps import dd2meters, meters2dd
 from ..proj.srs import SRS
+from PIL import Image
+from io import BytesIO
 
 from .. import settings
 USER_AGENT = settings.user_agent
@@ -592,8 +593,10 @@ class MapService():
 
 		#Make sure the stream is correct
 		if data is not None:
-			format = imghdr.what(None, data)
-			if format is None:
+			try:
+				image = Image.open(BytesIO(data))  # Attempt to open the binary data as an image
+				image.verify()  # Verifies that the file is a valid image
+			except (IOError, SyntaxError):  # If it's not a valid image, set data to None
 				data = None
 
 		if data is None:

--- a/core/georaster/img_utils.py
+++ b/core/georaster/img_utils.py
@@ -21,16 +21,19 @@
 
 
 import struct
-import imghdr
+from PIL import Image
+from io import BytesIO
 
 
 def isValidStream(data):
-	if data is None:
-		return False
-	format = imghdr.what(None, data)
-	if format is None:
-		return False
-	return True
+    if data is None:
+        return False
+    try:
+        image = Image.open(BytesIO(data))
+        image.verify()  # Verifies that the file is an image
+        return True
+    except (IOError, SyntaxError):
+        return False
 
 
 def getImgFormat(filepath):


### PR DESCRIPTION
imghdr was dropped in python 3.13 thus making it impossible to install the plugin in blender. I have removed the functionality of imghdr and replaced it with pillow.

Note: All the changes were supplied via chatgpt as I have no knowledge of python. I have tested it yesterday for a bit, and it seemed to work but as far I can see the checks are only to prevent invalidly formed data, which I did not test.