### PR TITLE
Fix TypeErro by typecasting int in random height calculation

### DIFF
--- a/operators/io_import_osm.py
+++ b/operators/io_import_osm.py
@@ -280,10 +280,10 @@ class OSM_IMPORT():
 							offset = None
 
 					if offset is None:
-						minH = self.defaultHeight - self.randomHeightThreshold
+						minH = int(self.defaultHeight - self.randomHeightThreshold)
 						if minH < 0 :
 							minH = 0
-						maxH = self.defaultHeight + self.randomHeightThreshold
+						maxH = int(self.defaultHeight + self.randomHeightThreshold)
 						offset = random.randint(minH, maxH)
 
 					#Extrude


### PR DESCRIPTION
This pull request addresses a TypeError in the io_import_osm.py file, which occurs when the code attempts to call random.randint() with float values. 

Error msg : TypeError: 'float' object cannot be interpreted as an integer

The problem arises when values such as minH and maxH are floats, but random.randint() expects integer arguments. This issue is typically encountered when generating random building heights, where minH and maxH are derived from height values that can be float types. 
Cause : The issue was introduced because random.randint() was being called with float values, which is invalid. This error surfaced after a recent merge.

Solution: minor change ->typecasting on assignment to minH and maxH. 

Testing:
The error was replicated using a building extrusion where the height tag was set to a float value. After the fix, the code works as intended, and the error no longer occurs.
