### PR TITLE
fix #955

### DIFF
--- a/operators/io_import_osm.py
+++ b/operators/io_import_osm.py
@@ -284,7 +284,7 @@ class OSM_IMPORT():
 						if minH < 0 :
 							minH = 0
 						maxH = self.defaultHeight + self.randomHeightThreshold
-						offset = random.randint(minH, maxH)
+						offset = random.randint(int(minH), int(maxH))
 
 					#Extrude
 					"""


### PR DESCRIPTION
Adopts the proposed solution from issue #955 TypeError:'float' object cannot be interpreted as an integer in random.randint() call