### PR TITLE
Import asc: Exclude nodata values for mesh creation

### DIFF
--- a/operators/io_import_asc.py
+++ b/operators/io_import_asc.py
@@ -267,8 +267,7 @@ class IMPORTGIS_OT_ascii_grid(Operator, ImportHelper):
                     # reproject world-space source coordinate, then transform back to target local-space
                     pt = rprjToScene.pt(pt[0] + reprojection['from'].x, pt[1] + reprojection['from'].y)
                     pt = (pt[0] - reprojection['to'].x, pt[1] - reprojection['to'].y)
-                
-                vertices.append(pt + (float(coldata[x]),))
+                vertices.append(pt + (val,))
 
         log.debug(f"Got vertices: {len(vertices)}")
         vertex_mask = [v is not None for v in vertices]


### PR DESCRIPTION
I tried to work on the following "#TODO" comment for the operator for importing asc-files. 
```
            for x in range(0, ncols, step):
                # TODO: exclude nodata values (implications for face generation)
                if not (self.importMode == 'CLOUD' and coldata[x] == nodata):
```

In my case, nodata filtering didn’t work because `nodata` is declared as  `float,` while `coldata[x] `was a `str` in my case, so the comparison returned False.
To address this, I restructured the logic so that nodata vertices are kept initially, and any faces referencing a nodata vertex are removed later in the process.
This approach worked for my ASC file, but it still needs more testing to confirm that it behaves correctly across different datasets.
