### PR TITLE
Update user agent in settings and add referer for Overpass API requests

### DIFF
--- a/core/settings.json
+++ b/core/settings.json
@@ -1,5 +1,5 @@
 {
 	"proj_engine": "AUTO",
 	"img_engine": "AUTO",
-	"user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
+	"user_agent": "BlenderGIS/2.2.14 (+https://github.com/domlysz/BlenderGIS)"
 }

--- a/operators/io_import_osm.py
+++ b/operators/io_import_osm.py
@@ -21,6 +21,7 @@ from ..core.utils import perf_clock
 
 from ..core import settings
 USER_AGENT = settings.user_agent
+OVERPASS_REFERER = "https://github.com/domlysz/BlenderGIS"
 
 PKG, SUBPKG = __package__.split('.', maxsplit=1)
 
@@ -665,7 +666,11 @@ class IMPORTGIS_OT_osm_query(Operator, OSM_IMPORT):
 
 		#Download from overpass api
 		log.debug('Requests overpass server : {}'.format(prefs.overpassServer))
-		api = overpy.Overpass(overpass_server=prefs.overpassServer, user_agent=USER_AGENT)
+		api = overpy.Overpass(
+			overpass_server=prefs.overpassServer,
+			referer=OVERPASS_REFERER,
+			user_agent=USER_AGENT,
+		)
 		query = queryBuilder(bbox, tags=list(self.filterTags), types=list(self.featureType), format='xml')
 		log.debug('Overpass query : {}'.format(query)) # can fails with non utf8 chars
 


### PR DESCRIPTION
Overpass APIs now require a referrer. Not sure if this is the best way to do this but it seems to work for me, and it can't be much ruder than spoofing a browser string 